### PR TITLE
Adding NodeStar Quorum Explorer

### DIFF
--- a/LedgerExplorers.md
+++ b/LedgerExplorers.md
@@ -1,9 +1,5 @@
 ## Ledger Explorers
 
-### [NodeStar](https://itunes.apple.com/us/app/nodestar-for-stellar/id1425168670?mt=8) - [source](https://github.com/foundero/NodeStar)   
-A Stellar Quorum Explorer that shows validators and their impact on other validator quorum sets.
-&nbsp;
-
 ### [steexp](https://steexp.com/) - [source](https://github.com/chatch/stellarexplorer)   
 steexp is human readable overview of operations carried out on the Stellar Network.  
 &nbsp;

--- a/LedgerExplorers.md
+++ b/LedgerExplorers.md
@@ -1,5 +1,9 @@
 ## Ledger Explorers
 
+### [NodeStar](https://itunes.apple.com/us/app/nodestar-for-stellar/id1425168670?mt=8) - [source](https://github.com/foundero/NodeStar)   
+A Stellar Quorum Explorer that shows validators and their impact on other validator quorum sets.
+&nbsp;
+
 ### [steexp](https://steexp.com/) - [source](https://github.com/chatch/stellarexplorer)   
 steexp is human readable overview of operations carried out on the Stellar Network.  
 &nbsp;

--- a/QuorumExplorers.md
+++ b/QuorumExplorers.md
@@ -1,0 +1,5 @@
+## Quorum Explorers
+
+### [NodeStar](https://itunes.apple.com/us/app/nodestar-for-stellar/id1425168670?mt=8) - [source](https://github.com/foundero/NodeStar)   
+A Stellar Quorum Explorer that shows validators and their impact on other validator quorum sets.
+&nbsp;

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Projects have been divided into nine unique categories:
 2. [Trading](Trading.md)
 3. [Forums](Forums.md)
 4. [Ledger Explorers](LedgerExplorers.md)
-5. [Libraries/APIs/Frameworks/Plug-ins](LibraryAPIsAndMore.md)
-6. [Remittance Applications](Remittance.md)
-7. [Tutorials and Documentation](TutorialsAndDocs.md)
-8. [Wallets](Wallets.md)
+5. [Quorum Explorers](QuorumExplorers.md)
+6. [Libraries/APIs/Frameworks/Plug-ins](LibraryAPIsAndMore.md)
+7. [Remittance Applications](Remittance.md)
+8. [Tutorials and Documentation](TutorialsAndDocs.md)
+9. [Wallets](Wallets.md)
 
 Projects are listed in each category in no particular order. 
 


### PR DESCRIPTION
Humble submission of NodeStar to the list.

Can we broaden the 'Ledger Explorers' category to include validator and quorum explorers too? or should I put NodeStar in a different category?